### PR TITLE
1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.1.3] - 2025-02-27
+
+### Changed
+
+- Fixed `vault` importer not extracting correct value from `medusa`
+
 ## [1.1.2] - 2025-02-26
 
 ### Changed
@@ -39,6 +45,7 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 - initial script, package, documentation and tests
 
+[1.1.3]: https://github.com/altibiz/rumor/compare/1.1.2...1.1.3
 [1.1.2]: https://github.com/altibiz/rumor/compare/1.1.1...1.1.2
 [1.1.1]: https://github.com/altibiz/rumor/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/altibiz/rumor/compare/1.0.0...1.1.0

--- a/src/main.nu
+++ b/src/main.nu
@@ -288,9 +288,10 @@ def "main import vault" [
 ]: nothing -> nothing {
   let trimmed_path = $path | str trim --char '/'
 
-  let last_component = $trimmed_path
+  let components = $trimmed_path
     | split row "/"
-    | last
+    | skip 1
+    | into cell-path
 
   let result = if $allow_fail {
       let result = try {
@@ -307,7 +308,7 @@ def "main import vault" [
 
   let files = $result
     | from yaml
-    | get $last_component
+    | get $components
     | get current
     | transpose name value
   for file in $files {


### PR DESCRIPTION
# Task

@HrvojeJuric

Fix `vault` importer not extracting correct value from `medusa`.

- [x] I read `CONTRIBUTING.md`
- [x] I modified `CHANGELOG.md`

## Description

Fixed `vault` importer not extracting correct value from `medusa` by getting from a component path and not just the last component.

## Testing

Tested manually on the nix package.

## Documentation

No additional documentation needed since it is a bug fix.
